### PR TITLE
Allow spans to be sampled client-side (head-based sampling)

### DIFF
--- a/pipelines/go.mod
+++ b/pipelines/go.mod
@@ -56,6 +56,8 @@ require (
 	google.golang.org/protobuf v1.28.1
 )
 
+require github.com/sethvargo/go-envconfig v0.8.2
+
 require github.com/lightstep/otel-launcher-go/lightstep/instrumentation v1.11.1
 
 require (

--- a/pipelines/go.sum
+++ b/pipelines/go.sum
@@ -157,6 +157,8 @@ github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:Om
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/sethvargo/go-envconfig v0.8.2 h1:DDUVuG21RMgeB/bn4leclUI/837y6cQCD4w8hb5797k=
+github.com/sethvargo/go-envconfig v0.8.2/go.mod h1:Iz1Gy1Sf3T64TQlJSvee81qDhf7YIlt8GMUX6yyNFs0=
 github.com/shirou/gopsutil/v3 v3.22.9 h1:yibtJhIVEMcdw+tCTbOPiF1VcsuDeTE4utJ8Dm4c5eA=
 github.com/shirou/gopsutil/v3 v3.22.9/go.mod h1:bBYl1kjgEJpWpxeHmLI+dVHWtyAwfcmSBLDsp2TNT8A=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/pipelines/sampler.go
+++ b/pipelines/sampler.go
@@ -1,0 +1,40 @@
+package pipelines
+
+import (
+	"context"
+	"github.com/sethvargo/go-envconfig"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"log"
+)
+
+type samplingConfig struct {
+	// SamplingEnabled turns on span sampling. This should be set alongside the
+	// SamplingPercent attribute. If sampling is disabled, all traces are sent
+	// to the endpoint.
+	SpanSamplingEnabled bool `env:"LS_SPAN_SAMPLING_ENABLED,default=false"`
+	// SamplingPercent is the percentage of spans will be sent to the endpoint,
+	// in the range 0-100. It is only consulted if SamplingEnabled is set to true
+	SpanSamplingPercent int `env:"LS_SPAN_SAMPLING_PERCENT,default=100"`
+}
+
+func newSampler() trace.Sampler {
+
+	var c samplingConfig
+
+	if err := envconfig.Process(context.Background(), &c); err != nil {
+		log.Printf("Could not load sampling config, default to AlwaysSample(): %s ", err)
+		return trace.AlwaysSample()
+	}
+
+	if !c.SpanSamplingEnabled || c.SpanSamplingPercent == 100 {
+		return trace.AlwaysSample()
+	}
+
+	if c.SpanSamplingPercent == 0 {
+		return trace.NeverSample()
+	}
+
+	return trace.ParentBased(
+		trace.TraceIDRatioBased(float64(c.SpanSamplingPercent) / 100.0),
+	)
+}

--- a/pipelines/sampler_test.go
+++ b/pipelines/sampler_test.go
@@ -1,0 +1,36 @@
+package pipelines
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"os"
+	"strconv"
+	"testing"
+)
+
+func Test_newSampler(t *testing.T) {
+	t.Run("Should always sample when no env is configured", func(t *testing.T) {
+		assert.Equal(t, trace.AlwaysSample(), newSampler())
+	})
+
+	t.Run("Should never sample when configured with 0%", func(t *testing.T) {
+		t.Cleanup(setSamplerEnvs(true, 0))
+		assert.Equal(t, trace.NeverSample(), newSampler())
+	})
+
+	t.Run("Should sample 75%", func(t *testing.T) {
+		t.Cleanup(setSamplerEnvs(true, 75))
+		sampler := newSampler()
+		assert.Equal(t, "ParentBased{root:TraceIDRatioBased{0.75}", sampler.Description()[:40])
+	})
+}
+
+func setSamplerEnvs(enabled bool, percent int) func() {
+	_ = os.Setenv("LS_SPAN_SAMPLING_ENABLED", strconv.FormatBool(enabled))
+	_ = os.Setenv("LS_SPAN_SAMPLING_PERCENT", strconv.Itoa(percent))
+
+	return func() {
+		_ = os.Unsetenv("LS_SPAN_SAMPLING_ENABLED")
+		_ = os.Unsetenv("LS_SPAN_SAMPLING_PERCENT")
+	}
+}

--- a/pipelines/trace.go
+++ b/pipelines/trace.go
@@ -36,7 +36,7 @@ func NewTracePipeline(c PipelineConfig) (func() error, error) {
 
 	bsp := trace.NewBatchSpanProcessor(spanExporter)
 	tp := trace.NewTracerProvider(
-		trace.WithSampler(trace.AlwaysSample()),
+		trace.WithSampler(newSampler()),
 		trace.WithSpanProcessor(bsp),
 		trace.WithResource(c.Resource),
 	)


### PR DESCRIPTION
Allow sampling to be configured with minimal changes to the upstream code. 

The idea is to maintain this fork and keep pulling updates till lightstep/otel-launcher-go#306 is resolved.